### PR TITLE
Skip $project for collections with dot fields names

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
     id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
-version = "10.5.0-SNAPSHOT"
+version = "10.6.0-SNAPSHOT"
 group = "org.mongodb.spark"
 
 description = "The official MongoDB Apache Spark Connect Connector."

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoInputPartitionHelper.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoInputPartitionHelper.java
@@ -135,11 +135,7 @@ final class MongoInputPartitionHelper {
       return Optional.empty();
     }
 
-    // Skip projection if any field has a literal dot in its name
-    boolean hasLiteralDotFields = Arrays.stream(schema.fields())
-        .anyMatch(f -> f.name().contains(".") && !(f.dataType() instanceof StructType));
-
-    if (hasLiteralDotFields) {
+    if (hasDottedFields(schema)) {
       return Optional.empty();
     }
 
@@ -149,6 +145,12 @@ final class MongoInputPartitionHelper {
         .map(f -> fieldPrefix + f.name())
         .forEach(f -> projections.append(f, new BsonInt32(1)));
     return Optional.of(new BsonDocument("$project", projections));
+  }
+
+  // Skip projection if any field has a literal dot in its name
+  private static boolean hasDottedFields(StructType schema) {
+    return Arrays.stream(schema.fields())
+        .anyMatch(field -> field.name().contains(".") && !(field.dataType() instanceof StructType));
   }
 
   private static Function<BsonDocument, List<BsonDocument>> mergePipelineFunction(

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoInputPartitionHelper.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoInputPartitionHelper.java
@@ -135,6 +135,14 @@ final class MongoInputPartitionHelper {
       return Optional.empty();
     }
 
+    // Skip projection if any field has a literal dot in its name
+    boolean hasLiteralDotFields = Arrays.stream(schema.fields())
+        .anyMatch(f -> f.name().contains(".") && !(f.dataType() instanceof StructType));
+
+    if (hasLiteralDotFields) {
+      return Optional.empty();
+    }
+
     String fieldPrefix = streamPublishFullDocumentOnly ? "fullDocument." : "";
     BsonDocument projections = new BsonDocument();
     Arrays.stream(schema.fields())

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoInputPartitionHelper.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoInputPartitionHelper.java
@@ -147,7 +147,14 @@ final class MongoInputPartitionHelper {
     return Optional.of(new BsonDocument("$project", projections));
   }
 
-  // Skip projection if any field has a literal dot in its name
+  /**
+   * Returns {@code true} if any non-struct field in the schema has a dot in its name.
+   * Such fields cannot be safely used in a MongoDB {@code $project} stage,
+   * as dots are interpreted as nested field delimiter.
+   *
+   * @param schema the Spark schema to check.
+   * @return {@code true} if a non struct field with a dot in its name exists, otherwise returns {@code false}.
+   */
   private static boolean hasDottedFields(StructType schema) {
     return Arrays.stream(schema.fields())
         .anyMatch(field -> field.name().contains(".") && !(field.dataType() instanceof StructType));


### PR DESCRIPTION
MongoDB interprets dots in $project keys as nested paths, causing fields                                                                                            with literal dots in their names to be stripped from results. Skip schema projection entirely when any non struct field name contains a dot.